### PR TITLE
Fix restricted thrift keyword usage

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/TaskStatus.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/TaskStatus.java
@@ -168,7 +168,7 @@ public class TaskStatus
     }
 
     @JsonProperty
-    @ThriftField(5)
+    @ThriftField(value = 5, name = "selfUri")
     public URI getSelf()
     {
         return self;


### PR DESCRIPTION
self is a thrift keyword and cannot be used in IDL.
This commit refactors the usage into selfUri.

Test plan - (Please fill in how you tested your changes)

Please make sure your submission complies with our [Development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [Formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), and [Commit Message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests) guidelines. Don't forget to follow our [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution) for any code copied from other projects.

Fill in the release notes towards the bottom of the PR description.
See [Release Notes Guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) for details.

```
== RELEASE NOTES ==

General Changes
* ...
* ...

Hive Changes
* ...
* ...
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```
